### PR TITLE
Dockerfile added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3-jdk-8-alpine
+
+COPY . /nexus-repository-apt/
+RUN cd /nexus-repository-apt/; sed -i 's/3.5.0-02/3.6.0-02/g' pom.xml; \
+    mvn;
+
+FROM sonatype/nexus3:3.6.0
+USER root
+RUN mkdir /opt/sonatype/nexus/system/net/staticsnow/ /opt/sonatype/nexus/system/net/staticsnow/nexus-repository-apt/ /opt/sonatype/nexus/system/net/staticsnow/nexus-repository-apt/1.0.2/; \
+    sed -i 's@nexus-repository-npm</feature>@nexus-repository-npm</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-apt</feature>@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/3.6.0-02/nexus-oss-feature-3.6.0-02-features.xml; \
+    sed -i 's@<feature name="nexus-repository-npm"@<feature name="nexus-repository-apt" description="net.staticsnow:nexus-repository-apt" version="1.0.2">\n        <details>net.staticsnow:nexus-repository-apt</details>\n        <bundle>mvn:net.staticsnow/nexus-repository-apt/1.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-npm"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/3.6.0-02/nexus-oss-feature-3.6.0-02-features.xml;
+#COPY target/nexus-repository-apt-1.0.2.jar /opt/sonatype/nexus/system/net/staticsnow/nexus-repository-apt/1.0.2/
+COPY --from=0 /nexus-repository-apt/target/nexus-repository-apt-1.0.2.jar /opt/sonatype/nexus/system/net/staticsnow/nexus-repository-apt/1.0.2/
+USER nexus

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ``` docker build -t nexus-repository-apt:3.6.0 .```
 
-### Run a dockercontainer from that image
+### Run a docker container from that image
 
 ``` docker run -d -p 8081:8081 --name nexus-repository-apt:3.6.0 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
   cd nexus-repository
   mvn
   ```
+### Build with docker and create an image based on nexus repository 3
+
+``` docker build -t nexus-repository-apt:3.6.0 .```
+
+### Run a dockercontainer from that image
+
+``` docker run -d -p 8081:8081 --name nexus-repository-apt:3.6.0 ```
+
+For further information like how to persist volumes view https://github.com/sonatype/docker-nexus3
+The application is now available from the browser on localhost:8081
 
 ### Install
 * Stop Nexus:


### PR DESCRIPTION
I added a Dockerfile to the project which installs nexus-repository-apt on the nexus 3.6.0 image. 

This is usefull for someone who simply wants to test how the plugin works, for anyone who runs nexus in docker already and wants to update (by changing the second FROM to their image). Also its a nice and easy way to find out if the plugin works with a new version of nexus (simply replace 3.6.0 and 3.6.0-02 with the newer version).

It would be possible to add build args to the dockerfile to support multiple versions but I had some trouble doing it and find it easier to manually change the Dockerfile