### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Build the pluguin:
 
   ```
-  cd nexus-repository
+  cd nexus-repository-apt
   mvn
   ```
 ### Build with docker and create an image based on nexus repository 3


### PR DESCRIPTION
Fix typo in the README.nd 

This pull request makes the following changes:
* cd nexus-repository-apt instead of just nexus-repository
