### PR TITLE
Hardcode LF as line separator to make this work in Windows

### DIFF
--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
@@ -172,6 +172,10 @@ public class AptHostedFacet
 
     StringBuilder sha256Builder = new StringBuilder();
     StringBuilder md5Builder = new StringBuilder();
+
+    String sep = System.getProperty("line.separator");
+    System.setProperty("line.separator", "\n");
+
     String releaseFile;
     try (CompressingTempFileStore store = buildPackageIndexes(tx, bucket, changes)) {
       for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
@@ -198,8 +202,10 @@ public class AptHostedFacet
     }
 
     aptFacet.put(releaseIndexName("Release"), new BytesPayload(releaseFile.getBytes(Charsets.UTF_8), AptMimeTypes.TEXT));
+    // releaseFile = releaseFile.replace("\r", "");
     byte[] inRelease = signingFacet.signInline(releaseFile);
     aptFacet.put(releaseIndexName("InRelease"), new BytesPayload(inRelease, AptMimeTypes.TEXT));
+    System.setProperty("line.separator", sep);
     byte[] releaseGpg = signingFacet.signExternal(releaseFile);
     aptFacet.put(releaseIndexName("Release.gpg"), new BytesPayload(releaseGpg, AptMimeTypes.SIGNATURE));
   }


### PR DESCRIPTION
This change allows the nexus apt repository plugin to run on Windows (IIS), by hardcoding LF as a line separator for the duration of the InRelease file creation.

This fixes #65, although it's a very hacky fix. I've tested it though and it does work.
