### PR TITLE
Nexus 3.14.0-04 requires version attribute in features configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The application will now be available from your browser at http://localhost:8081
 * Copy the bundle into `<nexus_dir>/system/net/staticsnow/nexus-repository-apt/1.0.9/nexus-repository-apt-1.0.9.jar`
 * Make the following additions marked with + to `<nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-core-feature/3.x.y/nexus-core-feature-3.x.y-features.xml`
    ```
-         <feature prerequisite="false" dependency="false">nexus-repository-maven</feature>
-   +     <feature prerequisite="false" dependency="false">nexus-repository-apt</feature>
+         <feature version="x.y.z" prerequisite="false" dependency="false">nexus-repository-maven</feature>
+   +     <feature version="1.0.9" prerequisite="false" dependency="false">nexus-repository-apt</feature>
      </feature>
    ```
    And


### PR DESCRIPTION
Nexus 3.14.0-04 refused to start when I'd made the suggested changes to <nexus_dir>/system/org/sonatype/nexus/assemblies/nexus-core-feature/3.x.y/nexus-core-feature-3.x.y-features.xml and I found that I needed to add in an attribute for the various bundle versions to make it happy.

This pull request makes the following changes:
* Updates README.md with the required additional attributes

