### PR TITLE
enable compilation on java10+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,28 @@
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
       
       <plugin>


### PR DESCRIPTION
When compiling on systems with java10 as on Ubuntu-18.04 + as in
$ mvn --version
  Apache Maven 3.5.2
  Maven home: /usr/share/maven
  Java version: 10.0.2, vendor: Oracle Corporation
  Java home: /usr/lib/jvm/java-11-openjdk-amd64
  Default locale: en_US, platform encoding: UTF-8
  OS name: "linux", version: "4.15.0-39-generic", arch: "amd64",
  family: "unix"

compilation fails with

[INFO] --- karaf-maven-plugin:4.0.9:features-generate-descriptor
  (plugin-feature) @ nexus-repository-apt ---
[WARNING] Error injecting:
  org.apache.karaf.tooling.features.GenerateDescriptorMojo
  java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException

[ERROR] Failed to execute goal
  [... ]A required class was missing while executing
  org.apache.karaf.tooling:karaf-maven-plugin:4.0.9:features-generate-descriptor:
  javax/xml/bind/JAXBException

Having the dependencies dropped from the standard class path declared
at karaf.tooling fixes the issue.
