### PR TITLE
Added help-text for PGP configuration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ A lot of awesome people have contributed to this project! Here they are:
 * [@jordiclariana](https://github.com/jordiclariana/) (Jordi Clariana)
 * [@Hermain](https://github.com/Hermain/) (Hermain)
 * [@DarthHater](https://github.com/darthhater/) (Jeffry Hesse)
+* [@MikkelHJuul](https://github.com/mikkelhjuul) (Mikkel Juul)
 
 And...
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ See https://help.github.com/articles/generating-a-new-gpg-key/
 To sign packages use; `gpg --export-secret-key --armor <Name or ID>` and passphrase in the hosted repository configuration.
 
 The private armored key should look like this:
-`
+```
 -----BEGIN PGP PRIVATE KEY BLOCK-----
 
 ...Base64 key...
 -----END PGP PRIVATE KEY BLOCK-----
-`
+```
 
 ## The Fine Print
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This will cause the plugin to be loaded and started with each startup of Nexus R
 ### Create gpg key required for signing apt-packages
 See https://help.github.com/articles/generating-a-new-gpg-key/
 
+To sign packages use; `gpg --export-secret-key --armor <Name or ID>` and passphrase in the hosted repository configuration.
+
 ## The Fine Print
 
 It is worth noting that this is **NOT SUPPORTED** by Sonatype, and is a contribution of Mike Poindexter's

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ See https://help.github.com/articles/generating-a-new-gpg-key/
 
 To sign packages use; `gpg --export-secret-key --armor <Name or ID>` and passphrase in the hosted repository configuration.
 
+The private armored key should look like this:
+`
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+...Base64 key...
+-----END PGP PRIVATE KEY BLOCK-----
+`
+
 ## The Fine Print
 
 It is worth noting that this is **NOT SUPPORTED** by Sonatype, and is a contribution of Mike Poindexter's

--- a/src/main/resources/static/rapture/NX/aptui/app/PluginStrings.js
+++ b/src/main/resources/static/rapture/NX/aptui/app/PluginStrings.js
@@ -28,7 +28,7 @@ Ext.define('NX.aptui.app.PluginStrings', {
     Repository_Facet_AptFacet_Flat_FieldLabel: 'Flat',
     Repository_Facet_AptFacet_Flat_HelpText: 'Is this repository flat?',
     Repository_Facet_AptSigningFacet_Keypair_FieldLabel: 'Signing Key',
-    Repository_Facet_AptSigningFacet_Keypair_HelpText: 'PGP signing key pair',
+    Repository_Facet_AptSigningFacet_Keypair_HelpText: 'PGP signing key pair (armored private key eg. gpg --export-private-key --armor <Name or ID>)',
     Repository_Facet_AptSigningFacet_Passphrase_FieldLabel: 'Passphrase',
     Repository_Facet_AptHostedFacet_AssetHistoryLimit_FieldLabel: 'Asset History Limit',
     Repository_Facet_AptHostedFacet_AssetHistoryLimit_HelpText: 'Number of versions of each package to keep.  If empty all versions will be kept.',

--- a/src/main/resources/static/rapture/NX/aptui/app/PluginStrings.js
+++ b/src/main/resources/static/rapture/NX/aptui/app/PluginStrings.js
@@ -28,7 +28,7 @@ Ext.define('NX.aptui.app.PluginStrings', {
     Repository_Facet_AptFacet_Flat_FieldLabel: 'Flat',
     Repository_Facet_AptFacet_Flat_HelpText: 'Is this repository flat?',
     Repository_Facet_AptSigningFacet_Keypair_FieldLabel: 'Signing Key',
-    Repository_Facet_AptSigningFacet_Keypair_HelpText: 'PGP signing key pair (armored private key eg. gpg --export-private-key --armor <Name or ID>)',
+    Repository_Facet_AptSigningFacet_Keypair_HelpText: 'PGP signing key pair (armored private key eg. gpg --export-secret-key --armor <Name or ID>)',
     Repository_Facet_AptSigningFacet_Passphrase_FieldLabel: 'Passphrase',
     Repository_Facet_AptHostedFacet_AssetHistoryLimit_FieldLabel: 'Asset History Limit',
     Repository_Facet_AptHostedFacet_AssetHistoryLimit_HelpText: 'Number of versions of each package to keep.  If empty all versions will be kept.',


### PR DESCRIPTION
Added help text to better guide the user through using the PGP key they have set up.

This pull request makes the following changes:
* added specification in README.md of how to use the PGP key that the linked guide suggests
* Minor change to the UI help text
![spectacle tj5594](https://user-images.githubusercontent.com/46485458/51302387-7ed3af80-1a32-11e9-9af2-34e6983ab2be.png)

It relates to the following issue #s:
* Fixes #20, Mitigates misunderstanding causing issues like #66, #55, #49, #13, #12, #9. 
* Reduces questions on gitter-channel like mine https://gitter.im/sonatype/nexus-developers?at=5c3ef81f32a8370605dd0b79 

I couldn't really figure out the CLA-thing the contributing guideline references. But this PR shouldn't contain anything (Il)legal. 

Thanks for the plugin