### PR TITLE
Use LF as line separator by removing CRs (for deployment under IIS on Windows)

### DIFF
--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
@@ -172,6 +172,10 @@ public class AptHostedFacet
 
     StringBuilder sha256Builder = new StringBuilder();
     StringBuilder md5Builder = new StringBuilder();
+
+    String sep = System.getProperty("line.separator");
+    System.setProperty("line.separator", "\n");
+
     String releaseFile;
     try (CompressingTempFileStore store = buildPackageIndexes(tx, bucket, changes)) {
       for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
@@ -198,8 +202,10 @@ public class AptHostedFacet
     }
 
     aptFacet.put(releaseIndexName("Release"), new BytesPayload(releaseFile.getBytes(Charsets.UTF_8), AptMimeTypes.TEXT));
+    // releaseFile = releaseFile.replace("\r", "");
     byte[] inRelease = signingFacet.signInline(releaseFile);
     aptFacet.put(releaseIndexName("InRelease"), new BytesPayload(inRelease, AptMimeTypes.TEXT));
+    System.setProperty("line.separator", sep);
     byte[] releaseGpg = signingFacet.signExternal(releaseFile);
     aptFacet.put(releaseIndexName("Release.gpg"), new BytesPayload(releaseGpg, AptMimeTypes.SIGNATURE));
   }

--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
@@ -198,11 +198,13 @@ public class AptHostedFacet
       releaseFile = buildReleaseFile(aptFacet.getDistribution(), store.getFiles().keySet(), md5Builder.toString(), sha256Builder.toString());
     }
 
+    releaseFile = releaseFile.replace("\r", "");
     aptFacet.put(releaseIndexName("Release"), new BytesPayload(releaseFile.getBytes(Charsets.UTF_8), AptMimeTypes.TEXT));
-    // releaseFile = releaseFile.replace("\r", "");
     byte[] inRelease = signingFacet.signInline(releaseFile);
+    inRelease = new String(inRelease, Charsets.UTF_8).replace("\r", "").getBytes();
     aptFacet.put(releaseIndexName("InRelease"), new BytesPayload(inRelease, AptMimeTypes.TEXT));
     byte[] releaseGpg = signingFacet.signExternal(releaseFile);
+    releaseGpg = new String(releaseGpg, Charsets.UTF_8).replace("\r", "").getBytes();
     aptFacet.put(releaseIndexName("Release.gpg"), new BytesPayload(releaseGpg, AptMimeTypes.SIGNATURE));
   }
 

--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedFacet.java
@@ -173,9 +173,6 @@ public class AptHostedFacet
     StringBuilder sha256Builder = new StringBuilder();
     StringBuilder md5Builder = new StringBuilder();
 
-    String sep = System.getProperty("line.separator");
-    System.setProperty("line.separator", "\n");
-
     String releaseFile;
     try (CompressingTempFileStore store = buildPackageIndexes(tx, bucket, changes)) {
       for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
@@ -205,7 +202,6 @@ public class AptHostedFacet
     // releaseFile = releaseFile.replace("\r", "");
     byte[] inRelease = signingFacet.signInline(releaseFile);
     aptFacet.put(releaseIndexName("InRelease"), new BytesPayload(inRelease, AptMimeTypes.TEXT));
-    System.setProperty("line.separator", sep);
     byte[] releaseGpg = signingFacet.signExternal(releaseFile);
     aptFacet.put(releaseIndexName("Release.gpg"), new BytesPayload(releaseGpg, AptMimeTypes.SIGNATURE));
   }


### PR DESCRIPTION
This change allows the nexus apt repository plugin to run on Windows (IIS), by removing CR as a line separator while all three index files (Release, InRelease, Release.gpg) are created

This fixes #65, in a less hacky way than before.