### PR TITLE
Use last downloaded handler

### DIFF
--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/AptFacetImpl.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/AptFacetImpl.java
@@ -109,9 +109,6 @@ public class AptFacetImpl
     if (asset == null) {
       return null;
     }
-    if (asset.markAsDownloaded()) {
-      tx.saveAsset(asset);
-    }
 
     return FacetHelper.toContent(asset, tx.requireBlob(asset.requireBlobRef()));
   }

--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedRecipe.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/hosted/AptHostedRecipe.java
@@ -36,6 +36,7 @@ import org.sonatype.nexus.repository.view.ViewFacet;
 import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler;
 import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler;
 import org.sonatype.nexus.repository.view.handlers.ExceptionHandler;
+import org.sonatype.nexus.repository.view.handlers.LastDownloadedHandler;
 import org.sonatype.nexus.repository.view.handlers.TimingHandler;
 import org.sonatype.nexus.repository.view.matchers.AlwaysMatcher;
 
@@ -115,6 +116,9 @@ public class AptHostedRecipe
   AptSigningHandler signingHandler;
 
   @Inject
+  LastDownloadedHandler lastDownloadedHandler;
+
+  @Inject
   public AptHostedRecipe(@Named(HostedType.NAME) Type type, @Named(AptFormat.NAME) Format format) {
     super(type, format);
   }
@@ -144,6 +148,7 @@ public class AptHostedRecipe
         .handler(partialFetchHandler)
         .handler(contentHeadersHandler)
         .handler(unitOfWorkHandler)
+        .handler(lastDownloadedHandler)
         .handler(snapshotHandler)
         .handler(signingHandler)
         .handler(hostedHandler).create());

--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/proxy/AptProxyRecipe.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/proxy/AptProxyRecipe.java
@@ -42,6 +42,7 @@ import org.sonatype.nexus.repository.view.ViewFacet;
 import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler;
 import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler;
 import org.sonatype.nexus.repository.view.handlers.ExceptionHandler;
+import org.sonatype.nexus.repository.view.handlers.LastDownloadedHandler;
 import org.sonatype.nexus.repository.view.handlers.TimingHandler;
 import org.sonatype.nexus.repository.view.matchers.AlwaysMatcher;
 
@@ -125,6 +126,9 @@ public class AptProxyRecipe
   AptSnapshotHandler snapshotHandler;
 
   @Inject
+  LastDownloadedHandler lastDownloadedHandler;
+
+  @Inject
   public AptProxyRecipe(@Named(ProxyType.NAME) Type type, @Named(AptFormat.NAME) Format format) {
     super(type, format);
   }
@@ -158,6 +162,7 @@ public class AptProxyRecipe
         .handler(contentHeadersHandler)
         .handler(unitOfWorkHandler)
         .handler(snapshotHandler)
+        .handler(lastDownloadedHandler)
         .handler(proxyHandler).create());
 
     builder.defaultHandlers(notFound());

--- a/src/main/java/net/staticsnow/nexus/repository/apt/internal/snapshot/AptSnapshotFacetSupport.java
+++ b/src/main/java/net/staticsnow/nexus/repository/apt/internal/snapshot/AptSnapshotFacetSupport.java
@@ -91,9 +91,6 @@ public abstract class AptSnapshotFacetSupport
     if (asset == null) {
       return null;
     }
-    if (asset.markAsDownloaded()) {
-      tx.saveAsset(asset);
-    }
 
     final Blob blob = tx.requireBlob(asset.requireBlobRef());
     return FacetHelper.toContent(asset, blob);


### PR DESCRIPTION
From NXRM 3.16 asset.markAsDownloaded has changed to needing to take an interval and it is expected that this will be done via AssetManager (introduced in 3.16). Switching to using the LastDownloadedHandler in the route means this code can work with 3.15.2 and will continue to work when 3.16 is released. 